### PR TITLE
[bash]: the output message should spell cppcheck.

### DIFF
--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -12,7 +12,7 @@ fi
 
 CPPCHECK=$(which cppcheck)
 if [ $? -ne 0 ]; then
-    echo "[!] cppecheck not installed. Unable to perform static analysis." >&2
+    echo "[!] cppcheck not installed. Unable to perform static analysis." >&2
     exit 1
 fi
 


### PR DESCRIPTION
`scripts/pre-commit.hook`: It need to output cppcheck, not cppecheck.